### PR TITLE
renaming api

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@
   branches:
     only:
       - development
-  version: 0.2.{build}.0-beta
+  version: 0.3.{build}.0-beta
   pull_requests:
     do_not_increment_build_number: true
   os: Visual Studio 2015
@@ -76,7 +76,7 @@
     except:
       - master
       - development
-  version: 0.2.{build}.0-branch
+  version: 0.3.{build}.0-branch
   pull_requests:
     do_not_increment_build_number: true
   os: Visual Studio 2015

--- a/src/PubNub.Async.Tests/Services/Access/AccessManagerTests.cs
+++ b/src/PubNub.Async.Tests/Services/Access/AccessManagerTests.cs
@@ -1,12 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
-using Flurl.Http;
-using Flurl.Http.Configuration;
 using Flurl.Http.Testing;
 using Moq;
 using Newtonsoft.Json;
@@ -49,7 +44,7 @@ namespace PubNub.Async.Tests.Services.Access
 
 			var mockRegistry = new Mock<IAccessRegistry>();
 			mockRegistry
-				.Setup(x => x.InForce(channel, authKey))
+				.Setup(x => x.Granted(channel, authKey))
 				.Returns(true);
 			mockRegistry
 				.Setup(x => x.Registration(channel, authKey))
@@ -92,7 +87,7 @@ namespace PubNub.Async.Tests.Services.Access
 
 			var mockRegistry = new Mock<IAccessRegistry>();
 			mockRegistry
-				.Setup(x => x.InForce(channel, authKey))
+				.Setup(x => x.Granted(channel, authKey))
 				.Returns(false);
 			
 			var subject = new AccessManager(client, mockRegistry.Object);

--- a/src/PubNub.Async.Tests/Services/Access/AccessRegistryTests.cs
+++ b/src/PubNub.Async.Tests/Services/Access/AccessRegistryTests.cs
@@ -32,7 +32,7 @@ namespace PubNub.Async.Tests.Services.Access
 			var subject = new AccessRegistry();
 			await subject.Register(channel, authKey, response);
 
-			var result = subject.InForce(channel, authKey);
+			var result = subject.Granted(channel, authKey);
 
 			Assert.True(result);
 		}
@@ -76,7 +76,7 @@ namespace PubNub.Async.Tests.Services.Access
 			var subject = new AccessRegistry();
 			await subject.Register(channel, authKey, response);
 
-			var result = subject.InForce(channel, authKey);
+			var result = subject.Granted(channel, authKey);
 
 			Assert.True(result);
 		}
@@ -102,7 +102,7 @@ namespace PubNub.Async.Tests.Services.Access
 			var subject = new AccessRegistry();
 			await subject.Register(channel, authKey, response);
 
-			var result = subject.InForce(channel, authKey);
+			var result = subject.Granted(channel, authKey);
 
 			Assert.False(result);
 		}
@@ -117,7 +117,7 @@ namespace PubNub.Async.Tests.Services.Access
 
 			var subject = new AccessRegistry();
 
-			var result = subject.InForce(channel, authKey);
+			var result = subject.Granted(channel, authKey);
 
 			Assert.False(result);
 		}

--- a/src/PubNub.Async/Services/Access/AccessManager.cs
+++ b/src/PubNub.Async/Services/Access/AccessManager.cs
@@ -44,7 +44,7 @@ namespace PubNub.Async.Services.Access
 			}
 
 			// if access grant is in force, return cached result
-			if (AccessRegistry.InForce(Channel, Settings.AuthenticationKey))
+			if (AccessRegistry.Granted(Channel, Settings.AuthenticationKey))
 			{
 				return await AccessRegistry.Registration(Channel, Settings.AuthenticationKey);
 			}

--- a/src/PubNub.Async/Services/Access/AccessRegistry.cs
+++ b/src/PubNub.Async/Services/Access/AccessRegistry.cs
@@ -41,7 +41,7 @@ namespace PubNub.Async.Services.Access
 				: null;
 		}
 
-		public bool InForce(Channel channel, string authenticationKey)
+		public bool Granted(Channel channel, string authenticationKey)
 		{
 			var key = KeyFor(channel, authenticationKey);
 			return ExpirationRegistry.ContainsKey(key) && ExpirationRegistry[key] > DateTime.UtcNow.Ticks;

--- a/src/PubNub.Async/Services/Access/IAccessRegistry.cs
+++ b/src/PubNub.Async/Services/Access/IAccessRegistry.cs
@@ -8,7 +8,7 @@ namespace PubNub.Async.Services.Access
 	{
 		Task Register(Channel channel, string authenticationKey, AccessGrantResponse response);
 		Task<AccessGrantResponse> Registration(Channel channel, string authenticationKey);
-		bool InForce(Channel channel, string authenticationKey);
+		bool Granted(Channel channel, string authenticationKey);
 		void Unregister(Channel channel, string authenticationKey);
 	}
 }


### PR DESCRIPTION
decided "Granted" was a better fitting name than "InForce"
