### PR TITLE
Presence wherenow

### DIFF
--- a/src/PubNub.Async.Presence/Extensions/PresenceExtensions.cs
+++ b/src/PubNub.Async.Presence/Extensions/PresenceExtensions.cs
@@ -96,5 +96,13 @@ namespace PubNub.Async.Presence.Extensions
 				.Subscribers<TState>()
 				.ConfigureAwait(false);
 		}
+
+		public static async Task<SubscriptionsResponse> Subscriptions(this IPubNubClient client)
+		{
+			return await PubNub.Environment
+				.Resolve<IPresenceService>(client)
+				.Subscriptions()
+				.ConfigureAwait(false);
+		}
 	}
 }

--- a/src/PubNub.Async.Presence/Models/PubNubSubscriptionsResponse.cs
+++ b/src/PubNub.Async.Presence/Models/PubNubSubscriptionsResponse.cs
@@ -1,0 +1,20 @@
+﻿using System.Net;
+using Newtonsoft.Json;
+
+namespace PubNub.Async.Presence.Models
+{
+	public class PubNubSubscriptionsResponse
+	{
+		[JsonProperty("status")]
+		public HttpStatusCode Status { get; set; }
+
+		[JsonProperty("message")]
+		public string Message { get; set; }
+
+		[JsonProperty("service")]
+		public string Service { get; set; }
+
+		[JsonProperty("payload")]
+		public PubNubSubscriptionsResponsePayload Payload { get; set; }
+	}
+}

--- a/src/PubNub.Async.Presence/Models/PubNubSubscriptionsResponsePayload.cs
+++ b/src/PubNub.Async.Presence/Models/PubNubSubscriptionsResponsePayload.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace PubNub.Async.Presence.Models
+{
+	public class PubNubSubscriptionsResponsePayload
+	{
+		[JsonProperty("channels")]
+		public string[] Channels { get; set; }
+	}
+}

--- a/src/PubNub.Async.Presence/Models/SubscriptionsResponse.cs
+++ b/src/PubNub.Async.Presence/Models/SubscriptionsResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace PubNub.Async.Presence.Models
+{
+	public class SubscriptionsResponse
+	{
+		public bool Success { get; set; }
+		public string Message { get; set; }
+
+		public string[] Channels { get; set; }
+	}
+}

--- a/src/PubNub.Async.Presence/PubNub.Async.Presence.csproj
+++ b/src/PubNub.Async.Presence/PubNub.Async.Presence.csproj
@@ -46,12 +46,15 @@
     </Compile>
     <Compile Include="Configuration\EnvironmentExtensions.cs" />
     <Compile Include="Extensions\PresenceExtensions.cs" />
+    <Compile Include="Models\PubNubSubscriptionsResponse.cs" />
+    <Compile Include="Models\PubNubSubscriptionsResponsePayload.cs" />
     <Compile Include="Models\Subscriber.cs" />
     <Compile Include="Models\SubscribersResponse.cs" />
     <Compile Include="Models\PubNubSubscribersResponse.cs" />
     <Compile Include="Models\PubNubSubscriberUuidsResponse.cs" />
     <Compile Include="Models\SessionStateResponse.cs" />
     <Compile Include="Models\PubNubStateResponse.cs" />
+    <Compile Include="Models\SubscriptionsResponse.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\IPresenceService.cs" />
     <Compile Include="Services\PresenceService.cs" />
@@ -97,6 +100,7 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
+    <None Include="PubNub.Async.Presence.nuspec" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />

--- a/src/PubNub.Async.Presence/PubNub.Async.Presence.nuspec
+++ b/src/PubNub.Async.Presence/PubNub.Async.Presence.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+
+<package>
+	<metadata>
+		<id>$id$</id>
+		<version>$version$</version>
+		<title>$title$</title>
+		<authors>$author$</authors>
+		<owners>$author$</owners>
+		<licenseUrl>https://raw.githubusercontent.com/engenb/pubnub.async.pcl/setup/LICENSE</licenseUrl>
+		<projectUrl>https://github.com/engenb/pubnub.async.pcl</projectUrl>
+		<!--iconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</iconUrl-->
+		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<description>$description$</description>
+		<releaseNotes>
+		</releaseNotes>
+		<copyright>Copyright 2016</copyright>
+		<tags>pubnub async pcl xamarin presence</tags>
+	</metadata>
+</package>

--- a/src/PubNub.Async.Presence/Services/IPresenceService.cs
+++ b/src/PubNub.Async.Presence/Services/IPresenceService.cs
@@ -13,5 +13,7 @@ namespace PubNub.Async.Presence.Services
 		
 		Task<SubscribersResponse<TState>> Subscribers<TState>(bool includeSessionState = false, bool includeUuids = true)
 			where TState : class;
+
+		Task<SubscriptionsResponse> Subscriptions();
 	}
 }

--- a/src/PubNub.Async.Presence/Services/PresenceService.cs
+++ b/src/PubNub.Async.Presence/Services/PresenceService.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Flurl;
 using Flurl.Http;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using PubNub.Async.Configuration;
 using PubNub.Async.Extensions;
 using PubNub.Async.Models.Channel;
@@ -102,6 +101,24 @@ namespace PubNub.Async.Presence.Services
 				Subscribers = subscriberUuids.Subscribers?
 					.Select(x => new Subscriber<TState> {Uuid = x})
 					.ToArray()
+			};
+		}
+
+		public async Task<SubscriptionsResponse> Subscriptions()
+		{
+			var response = await Environment.Host
+				.AppendPathSegments("v2", "presence")
+				.AppendPathSegments("sub_key", Environment.SubscribeKey)
+				.AppendPathSegments("uuid", Environment.SessionUuid)
+				.GetAsync()
+				.ProcessResponse()
+				.ReceiveJson<PubNubSubscriptionsResponse>();
+
+			return new SubscriptionsResponse
+			{
+				Success = response.Status == HttpStatusCode.OK,
+				Message = response.Message,
+				Channels = response.Payload?.Channels
 			};
 		}
 


### PR DESCRIPTION
fetches subscribed channels for an auth key aka "wherenow" in pn client.  didn't add extensions for string/channel as this is client level only.  may need to consider a better approach for global-level operations, such as this (another example is global-herenow)
